### PR TITLE
GPII-288: LogLocalSettings.cmd for Windows

### DIFF
--- a/LogLocalSettings.cmd
+++ b/LogLocalSettings.cmd
@@ -1,0 +1,6 @@
+@echo off
+rem You can change the location where the settings logs are saved by replacing 
+rem 'C:\gpiilogs_pilot2' in the following line by another location. Don't use a location containing spaces!!
+@echo on
+node ../node_modules/universal/gpii/node_modules/matchMaker/src/LogSettings.js C:\gpiilogs_pilot2
+@echo off


### PR DESCRIPTION
This file was previously submitted in another pull request (https://github.com/GPII/windows/pull/49) and is now available as a download in the installation instructions. Integrating it into the pilotsConfig repo will allow us to reduce the number of downloads by one.
