### PR TITLE
Removing two duplicate entries from solutions list

### DIFF
--- a/installedSolutions.json
+++ b/installedSolutions.json
@@ -44,14 +44,6 @@
     },
 
     {
-        "id": "org.gnome.desktop.interface"
-    },
-
-    {
-        "id": "org.gnome.nautilus"
-    },
-
-    {
         "id": "com.microsoft.windows.highContrast"
     },
 


### PR DESCRIPTION
The following entries were duplicates:
- "org.gnome.desktop.interface" 
- "org.gnome.nautilus"
